### PR TITLE
update Mox.mutate to take context object

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -146,7 +146,7 @@ In a chain of actions, these actions should be called before response actions.
 
 - #### `.mutate(fn: Function)` => `Actions`
 
-  This action allows programmatic modification of the response payload. `fn` has the signature `(response: any) => any`. Example:
+  This action allows programmatic modification of the response payload. `fn` has the signature `(response: any, context: { req: $Request, res: $Response }) => any`. Example:
 
   ```javascript
   MoxRouter.get('/api/object').mutate(obj => {

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -147,8 +147,8 @@ export default class Actions implements ActionsI {
     return this;
   }
 
-  mutate(mutator: (response: any) => any): Actions {
-    this._addResTransform(body => mutator(body));
+  mutate(mutator: (response: any, context: { req: $Request, res: $Response }) => any): Actions {
+    this._addResTransform((body, { req, res }: Context) => mutator(body, { req, res }));
     return this;
   }
 

--- a/src/__tests__/e2e-test.js
+++ b/src/__tests__/e2e-test.js
@@ -109,13 +109,20 @@ describe('Mox', () => {
     });
 
     test('mutate', async () => {
-      Mox.get(`/${ver}/object`).mutate(val => ({ ...val, extra: 'this is extra' }));
+      Mox.get(`/${ver}/object`).mutate((val, { req, res }) => ({
+        ...val,
+        extra: 'this is extra',
+        hasReq: !!req,
+        hasResp: !!res,
+      }));
       const { body } = await simpleRequest(`/${ver}/object`);
       expect(JSON.parse(body)).toEqual({
         id: 'zxcv',
         name: 'Bob',
         location: 'Palo Alto, CA',
         extra: 'this is extra',
+        hasReq: true,
+        hasResp: true,
       });
     });
 

--- a/src/types.js
+++ b/src/types.js
@@ -32,7 +32,7 @@ export interface ActionsI {
   // res transforms
   res(fn: (res: $Response) => void): ActionsI;
   status(statusCode: number): ActionsI;
-  mutate(mutator: (response: any) => any): ActionsI;
+  mutate(mutator: (response: any, context: { req: $Request, res: $Response }) => any): ActionsI;
   mock(response: any, statusCode?: number): ActionsI;
 }
 


### PR DESCRIPTION
By passing context, mutate handler can use request and response to make context-aware mutations. For example - user can decide what mutation to do based on query param.